### PR TITLE
Integration with orchestra/canvas

### DIFF
--- a/src/Canvas/Package.php
+++ b/src/Canvas/Package.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\Stubs\Canvas;
+
+class Package extends \Orchestra\Canvas\Core\Presets\Package
+{
+    /**
+     * Get custom stub path.
+     */
+    public function getCustomStubPath(): ?string
+    {
+        return __DIR__.'/../../stubs';
+    }
+}


### PR DESCRIPTION
This would allow any developer to use Spatie stubs instead of the default bundled in `orchestra/canvas` for Package development.

### Installation

On any package project.

```
composer require --dev "spatie/laravel-stubs" "orchestra/canvas:^5.2"
```

And then run

```
./vendor/bin/canvas preset package
```

And then modify the generated `canvas.yaml` file:

```yaml
preset: Spatie\Stubs\Canvas\Package
namespace: YourPackageNamespace
```